### PR TITLE
proof of fset2P should not rely on intuition

### DIFF
--- a/finmap.v
+++ b/finmap.v
@@ -1225,7 +1225,13 @@ by move/negPf=> nBa; apply/fsetP=> x; rewrite !inE; case: eqP => // ->.
 Qed.
 
 Lemma fset2P x a b : reflect (x = a \/ x = b) (x \in [fset a; b]).
-Proof. by rewrite !inE; apply: (iffP orP) => [] [] /eqP; intuition. Qed.
+Proof.
+rewrite !inE; apply: (iffP orP) => [] [] /eqP ->. 
+      by left. 
+    by right. 
+  by left. 
+by right. 
+Qed.
 
 Lemma in_fset2 x a b : (x \in [fset a; b]) = (x == a) || (x == b).
 Proof. by rewrite !inE. Qed.


### PR DESCRIPTION
which introduces a spurious dependence on a section variable K'

In previous version, compiled on coq 8.6 with master version 0dd56bae63cca37e5be8c22ffea8e47d1ef500fc of math-comp, fset2P had statement:

forall (K : choiceType) choiceType -> (x a b : K),
       reflect (x = a \/ x = b) (x \in [fset a; b])
The spurious choiceType was probably introduced with commit 
0679fb717835b95f06b855b96b18d838b2f58462
that added K' in the context.
