### PR TITLE
anticipate `seq` lemma renamings

### DIFF
--- a/finmap.v
+++ b/finmap.v
@@ -217,7 +217,7 @@ split=> [eq_ss'|eq_ss' k]; last by rewrite -E eq_ss' E.
 rewrite /f; have peq_ss' : perm_eq (undup s) (undup s').
   by apply: uniq_perm_eq; rewrite ?undup_uniq // => x; rewrite !mem_undup.
 rewrite (@choose_id _ _ _ (undup s')) //=; apply: eq_choose => x /=.
-by apply: sym_left_transitive; [exact: perm_eq_sym|exact: perm_eq_trans|].
+by apply: sym_left_transitive; [exact: perm_eq_sym | exact: @perm_eq_trans|].
 Qed.
 End SortKeys.
 End SortKeys.


### PR DESCRIPTION
- specify no-implcits for `perm_eq_trans`, so that the temporary alias
to the new `perm_trans` name introduced by math-comp/math-comp#345 will
work (it has maximal implicits, as the `deprecate` feature does not
support on-demand implicits).