### PR TITLE
fix compatibility with `seq` renaming

### DIFF
--- a/finmap.v
+++ b/finmap.v
@@ -217,7 +217,7 @@ split=> [eq_ss'|eq_ss' k]; last by rewrite -E eq_ss' E.
 rewrite /f; have peq_ss' : perm_eq (undup s) (undup s').
   by apply: uniq_perm_eq; rewrite ?undup_uniq // => x; rewrite !mem_undup.
 rewrite (@choose_id _ _ _ (undup s')) //=; apply: eq_choose => x /=.
-by apply: sym_left_transitive; [exact: perm_eq_sym | exact: @perm_eq_trans|].
+by apply: sym_left_transitive; [exact: perm_eq_sym | exact: (@perm_eq_trans)|].
 Qed.
 End SortKeys.
 End SortKeys.


### PR DESCRIPTION
- actually fix the compatibility issue: the overloaded notation for
`@perm_eq_trans` is at level 10 (it has to, to factor with the generic
`@` rule), so it is not parsed by the `constr` entry used by tactics,
which instead uses a _duplicate_ generic `@` rule. Worse that rule does
_not_ raise an error when the `@` argument is not a constant, and just
silently acts as a no-op. Bottom line, overloaded `@my_id` notation
should be passed to tactics as `(@my_id)`.