### PR TITLE
Coq 8.12 ok in opam file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,13 @@ env:
   - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.9"
   - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.10"
   - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.11"
+  - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.12"
   - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.7"
   - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.8"
   - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.9"
   - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.10"
   - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.11"
+  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.12"
 
 install: |
   # Prepare the COQ container

--- a/opam
+++ b/opam
@@ -12,7 +12,7 @@ build: [ make "-j" "%{jobs}%" ]
 install: [ make "install" ]
 
 depends: [
-  "coq" { (>= "8.7" & < "8.12~") | (= "dev") }
+  "coq" { (>= "8.7" & < "8.13~") | (= "dev") }
   "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.12~") | (= "dev") }
   "coq-mathcomp-bigenough" { (>= "1.0.0" & < "1.1~")  | (= "dev") }
 ]


### PR DESCRIPTION
It looks like compilation is fine with Coq 8.12.
(The change to `.travis.yml` is redundant with PR #69 .)