### PR TITLE
Remove dependency on bigenough

### DIFF
--- a/coq-mathcomp-finmap.opam
+++ b/coq-mathcomp-finmap.opam
@@ -19,8 +19,7 @@ build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
   "coq" { (>= "8.10" & < "8.14~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.13~") | (= "dev") }
-  "coq-mathcomp-bigenough" {>= "1.0.0"}
+  "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.14~") | (= "dev") }
 ]
 
 tags: [


### PR DESCRIPTION
It looks like dependency on `coq-mathcomp-bigenough` is not needed anymore in this library. 
This PR removes it. In addition I also bumped version of `coq-mathcomp` to `1.14~` to match the bound in [opam-coq-archive](https://github.com/coq/opam-coq-archive/blob/e3df8cc08d7bfcdced34f211e930256b00d907c3/released/packages/coq-mathcomp-finmap/coq-mathcomp-finmap.1.5.1/opam#L21)
I suspect that I should also modify dependencies in some other files related to building & distribution, I would be happy to be guided on how to do this properly. 

The motivation for this change is stems from the fact that `coq-mathcomp-bigenough` fails to compile on `mathcomp-dev/coq-dev` CI [(for example, see here)](https://github.com/math-comp/finmap/runs/4241949557?check_suite_focus=true)
If you'll find it useful, I can submit this as a separate issue on `coq-mathcomp-bigenough` repo. 

