### PR TITLE
update CI for mathcomp-1.13 and remove bigenough dependency

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -1,4 +1,6 @@
-name: CI
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+name: Docker CI
 
 on:
   push:
@@ -15,16 +17,16 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'mathcomp/mathcomp:1.11.0-coq-8.10'
           - 'mathcomp/mathcomp:1.11.0-coq-8.11'
           - 'mathcomp/mathcomp:1.11.0-coq-8.12'
-          - 'mathcomp/mathcomp:1.12.0-coq-8.10'
           - 'mathcomp/mathcomp:1.12.0-coq-8.11'
           - 'mathcomp/mathcomp:1.12.0-coq-8.12'
           - 'mathcomp/mathcomp:1.12.0-coq-8.13'
-          - 'mathcomp/mathcomp-dev:coq-8.10'
+          - 'mathcomp/mathcomp:1.13.0-coq-8.14'
           - 'mathcomp/mathcomp-dev:coq-8.11'
           - 'mathcomp/mathcomp-dev:coq-8.12'
+          - 'mathcomp/mathcomp-dev:coq-8.13'
+          - 'mathcomp/mathcomp-dev:coq-8.14'
           - 'mathcomp/mathcomp-dev:coq-dev'
       fail-fast: false
     steps:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
+<!---
+This file was generated from `meta.yml`, please do not edit manually.
+Follow the instructions on https://github.com/coq-community/templates to regenerate.
+--->
 # Finite maps
 
-[![CI][action-shield]][action-link]
+[![Docker CI][docker-action-shield]][docker-action-link]
 
-[action-shield]: https://github.com/math-comp/finmap/workflows/CI/badge.svg?branch=master
-[action-link]: https://github.com/math-comp/finmap/actions?query=workflow%3ACI
+[docker-action-shield]: https://github.com/math-comp/finmap/workflows/Docker%20CI/badge.svg?branch=master
+[docker-action-link]: https://github.com/math-comp/finmap/actions?query=workflow:"Docker%20CI"
 
 
 
@@ -20,10 +24,9 @@ which will be used to subsume notations for finite sets, eventually.
   - Cyril Cohen (initial)
   - Kazuhiko Sakaguchi
 - License: [CeCILL-B](CECILL-B)
-- Compatible Coq versions: Coq 8.10 to 8.13
+- Compatible Coq versions: Coq 8.11 to 8.14
 - Additional dependencies:
   - [MathComp ssreflect 1.10 to 1.12](https://math-comp.github.io)
-  - [MathComp bigenough 1.0.0 or later](https://github.com/math-comp/bigenough)
 - Coq namespace: `mathcomp.finmap`
 - Related publication(s): none
 

--- a/coq-mathcomp-finmap.opam
+++ b/coq-mathcomp-finmap.opam
@@ -1,3 +1,6 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
 opam-version: "2.0"
 maintainer: "Cyril Cohen <cyril.cohen@inria.fr>"
 version: "dev"
@@ -15,12 +18,11 @@ types). This includes support for functions with finite support and
 multisets. The library also contains a generic order and set libary,
 which will be used to subsume notations for finite sets, eventually."""
 
-build: [make "-j%{jobs}%" ]
+build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" { (>= "8.10" & < "8.14~") | (= "dev") }
-  "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.13~") | (= "dev") }
-  "coq-mathcomp-bigenough" {>= "1.0.0"}
+  "coq" { (>= "8.11" & < "8.15~") | (= "dev") }
+  "coq-mathcomp-ssreflect" { (>= "1.11.0" & < "1.14~") | (= "dev") }
 ]
 
 tags: [

--- a/meta.yml
+++ b/meta.yml
@@ -31,17 +31,13 @@ license:
   file: CECILL-B
 
 supported_coq_versions:
-  text: Coq 8.10 to 8.13
-  opam: '{ (>= "8.10" & < "8.14~") | (= "dev") }'
+  text: Coq 8.11 to 8.14
+  opam: '{ (>= "8.11" & < "8.15~") | (= "dev") }'
 
 tested_coq_opam_versions:
-- version: '1.11.0-coq-8.10'
-  repo: 'mathcomp/mathcomp'
 - version: '1.11.0-coq-8.11'
   repo: 'mathcomp/mathcomp'
 - version: '1.11.0-coq-8.12'
-  repo: 'mathcomp/mathcomp'
-- version: '1.12.0-coq-8.10'
   repo: 'mathcomp/mathcomp'
 - version: '1.12.0-coq-8.11'
   repo: 'mathcomp/mathcomp'
@@ -49,29 +45,26 @@ tested_coq_opam_versions:
   repo: 'mathcomp/mathcomp'
 - version: '1.12.0-coq-8.13'
   repo: 'mathcomp/mathcomp'
-- version: 'coq-8.10'
-  repo: 'mathcomp/mathcomp-dev'
+- version: '1.13.0-coq-8.14'
+  repo: 'mathcomp/mathcomp'  
 - version: 'coq-8.11'
   repo: 'mathcomp/mathcomp-dev'
 - version: 'coq-8.12'
   repo: 'mathcomp/mathcomp-dev'
-# to uncomment after merging math-comp/math-comp#688
-# - version: 'coq-8.13'
-#   repo: 'mathcomp/mathcomp-dev'
+- version: 'coq-8.13'
+  repo: 'mathcomp/mathcomp-dev'
+- version: 'coq-8.14'
+  repo: 'mathcomp/mathcomp-dev'  
 - version: 'coq-dev'
   repo: 'mathcomp/mathcomp-dev'
 
 dependencies:
 - opam:
     name: coq-mathcomp-ssreflect
-    version: '{ (>= "1.11.0" & < "1.13~") | (= "dev") }'
+    version: '{ (>= "1.11.0" & < "1.14~") | (= "dev") }'
   description: |-
     [MathComp ssreflect 1.10 to 1.12](https://math-comp.github.io)
-- opam:
-    name: coq-mathcomp-bigenough
-    version: '{>= "1.0.0"}'
-  description: |-
-    [MathComp bigenough 1.0.0 or later](https://github.com/math-comp/bigenough)
+
 namespace: mathcomp.finmap
 
 keywords:


### PR DESCRIPTION
I updated the metadata and regenerated everything using up-to-date coq-community templates. In particular, this drops the spurious dependency on bigenough. I hope this is the right way to do this. 