### PR TITLE
Fix the _.[_ <- _] notation priorities w.r.t Coq.Parray

### DIFF
--- a/finmap.v
+++ b/finmap.v
@@ -354,7 +354,7 @@ Reserved Notation "\bigcup_ ( i 'in' A ) F"
 
 Reserved Notation "{fmap T }" (at level 0, format "{fmap  T }").
 Reserved Notation "x .[ k <- v ]"
-  (at level 2, k at level 200, v at level 200, format "x .[ k  <-  v ]").
+  (at level 2, left associativity, format "x .[ k  <-  v ]").
 Reserved Notation "x .[~ k ]" (at level 2, k at level 200, format "x .[~  k ]").
 Reserved Notation "x .[& k ]" (at level 2, k at level 200, format "x .[&  k ]").
 Reserved Notation "x .[\ k ]" (at level 2, k at level 200, format "x .[\  k ]").


### PR DESCRIPTION
Currently, both Coq.Parray and finmap define this notation, using
different priorities. This disallows import both libraries.