### PR TITLE
drop old verions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ which will be used to subsume notations for finite sets, eventually.
   - Cyril Cohen (initial)
   - Kazuhiko Sakaguchi
 - License: [CeCILL-B](CECILL-B)
-- Compatible Coq versions: Coq 8.11 to 8.15
+- Compatible Coq versions: Coq 8.13 to 8.15
 - Additional dependencies:
-  - [MathComp ssreflect 1.11 to 1.14](https://math-comp.github.io)
+  - [MathComp ssreflect 1.12 to 1.14](https://math-comp.github.io)
 - Coq namespace: `mathcomp.finmap`
 - Related publication(s): none
 

--- a/meta.yml
+++ b/meta.yml
@@ -31,25 +31,13 @@ license:
   file: CECILL-B
 
 supported_coq_versions:
-  text: Coq 8.11 to 8.15
-  opam: '{ (>= "8.11" & < "8.16~") | (= "dev") }'
+  text: Coq 8.13 to 8.15
+  opam: '{ (>= "8.13" & < "8.16~") | (= "dev") }'
 
 tested_coq_opam_versions:
-- version: '1.11.0-coq-8.11'
-  repo: 'mathcomp/mathcomp'
-- version: '1.11.0-coq-8.12'
-  repo: 'mathcomp/mathcomp'
-- version: '1.12.0-coq-8.11'
-  repo: 'mathcomp/mathcomp'
-- version: '1.12.0-coq-8.12'
-  repo: 'mathcomp/mathcomp'
 - version: '1.12.0-coq-8.13'
   repo: 'mathcomp/mathcomp'
 - version: '1.12.0-coq-8.14'
-  repo: 'mathcomp/mathcomp'
-- version: '1.13.0-coq-8.11'
-  repo: 'mathcomp/mathcomp'
-- version: '1.13.0-coq-8.12'
   repo: 'mathcomp/mathcomp'
 - version: '1.13.0-coq-8.13'
   repo: 'mathcomp/mathcomp'
@@ -57,22 +45,12 @@ tested_coq_opam_versions:
   repo: 'mathcomp/mathcomp'
 - version: '1.13.0-coq-8.15'
   repo: 'mathcomp/mathcomp'
-- version: '1.14.0-coq-8.11'
-  repo: 'mathcomp/mathcomp'
-- version: '1.14.0-coq-8.12'
-  repo: 'mathcomp/mathcomp'
 - version: '1.14.0-coq-8.13'
   repo: 'mathcomp/mathcomp'
 - version: '1.14.0-coq-8.14'
   repo: 'mathcomp/mathcomp'
 - version: '1.14.0-coq-8.15'
   repo: 'mathcomp/mathcomp'
-- version: '1.14.0-coq-dev'
-  repo: 'mathcomp/mathcomp'
-- version: 'coq-8.11'
-  repo: 'mathcomp/mathcomp-dev'
-- version: 'coq-8.12'
-  repo: 'mathcomp/mathcomp-dev'
 - version: 'coq-8.13'
   repo: 'mathcomp/mathcomp-dev'
 - version: 'coq-8.14'
@@ -85,9 +63,9 @@ tested_coq_opam_versions:
 dependencies:
 - opam:
     name: coq-mathcomp-ssreflect
-    version: '{ (>= "1.11.0" & < "1.15~") | (= "dev") }'
+    version: '{ (>= "1.12.0" & < "1.15~") | (= "dev") }'
   description: |-
-    [MathComp ssreflect 1.11 to 1.14](https://math-comp.github.io)
+    [MathComp ssreflect 1.12 to 1.14](https://math-comp.github.io)
 
 namespace: mathcomp.finmap
 


### PR DESCRIPTION
This drops support for Coq < 8.13 (not supported by MathComp anymore) and for ssreflect 1.11 (it looks like meta.yml was partially updated regarding the ssreflect version).